### PR TITLE
SATA Link Power Policy Control

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,8 +9,11 @@ use backlight::Backlight;
 use graphics::Graphics;
 use kbd_backlight::KeyboardBacklight;
 use pstate::PState;
+use scsi::{ScsiHosts, ScsiPower};
 
 fn performance() -> io::Result<()> {
+    ScsiHosts::new().set_power_management_policy(&["med_power_with_dipm", "max_performance"])?;
+
     {
         let mut pstate = PState::new()?;
         pstate.set_min_perf_pct(50)?;
@@ -22,6 +25,8 @@ fn performance() -> io::Result<()> {
 }
 
 fn balanced() -> io::Result<()> {
+    ScsiHosts::new().set_power_management_policy(&["med_power_with_dipm", "medium_power"])?;
+
     {
         let mut pstate = PState::new()?;
         pstate.set_min_perf_pct(0)?;
@@ -51,6 +56,8 @@ fn balanced() -> io::Result<()> {
 }
 
 fn battery() -> io::Result<()> {
+    ScsiHosts::new().set_power_management_policy(&["med_power_with_dipm", "min_power"])?;
+
     {
         let mut pstate = PState::new()?;
         pstate.set_min_perf_pct(0)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod graphics;
 mod module;
 mod pci;
 mod pstate;
+mod scsi;
 mod util;
 
 pub static DBUS_NAME: &'static str = "com.system76.PowerDaemon";

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -1,0 +1,80 @@
+use std::io;
+use std::path::PathBuf;
+use util::write_file;
+
+const HOSTS: &str = "/sys/class/scsi_host/";
+
+pub trait ScsiPower {
+    fn set_power_management_policy(&self, profiles: &[&str]) -> io::Result<()>;
+}
+
+pub struct ScsiHosts(Vec<ScsiHost>);
+
+impl ScsiHosts {
+    pub fn new() -> ScsiHosts {
+        let mut hosts = Vec::new();
+        for host in (0..).map(ScsiHost::get) {
+            match host {
+                Some(host) => hosts.push(host),
+                None => break
+            }
+        }
+
+        ScsiHosts(hosts)
+    }
+}
+
+impl ScsiPower for ScsiHosts {
+    fn set_power_management_policy(&self, profiles: &[&str]) -> io::Result<()> {
+        self.0.iter().map(|host| host.set_power_management_policy(profiles)).collect()
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ScsiHost {
+    host: u32,
+    link_power_management_policy: PathBuf,
+}
+
+impl ScsiHost {
+    pub fn get(host: u32) -> Option<ScsiHost> {
+        let path = PathBuf::from([HOSTS, "host", &host.to_string(), "/"].concat());
+        if !path.exists() {
+            return None;
+        }
+
+        let link_power_management_policy = path.join("link_power_management_policy");
+        if !link_power_management_policy.exists() {
+            return None;
+        }
+
+        Some(ScsiHost {
+            host,
+            link_power_management_policy,
+        })
+    }
+}
+
+impl ScsiPower for ScsiHost {
+    fn set_power_management_policy(&self, profiles: &[&str]) -> io::Result<()> {
+        if profiles.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "at least one scsi power management profile should be specified"
+            ));
+        }
+
+        let mut last_result = unsafe { ::std::mem::uninitialized() };
+
+        for prof in profiles {
+            eprintln!("Setting scsi_host {} to {}", self.host, prof);
+            last_result = write_file(&self.link_power_management_policy, prof);
+            match last_result.as_ref() {
+                Ok(_) => break,
+                Err(ref why) => eprintln!("Failed to set scsi_host {} to {}: {}", self.host, prof, why)
+            }
+        }
+
+        last_result
+    }
+}


### PR DESCRIPTION
- SCSI hosts may now have their power policy controlled
  - "med_power_with_dipm" will be attempted first on all levels
    - The battery profile will then attempt "min_power"
    - The balanced profile will attempt "medium_power"
    - The performance profile will attempt "max_performance"