### PR TITLE
Enable Runtime Power Management for PCI Devices

### DIFF
--- a/src/kernel_parameters.rs
+++ b/src/kernel_parameters.rs
@@ -119,7 +119,21 @@ dynamic_parameters! {
     PowerSaveController {
         power_save_controller: "/sys/module/{}/parameters/power_save_controller"
     }
+}
 
+/// Control whether a device uses, or does not use, runtime power management.
+pub enum RuntimePowerManagement {
+    On,
+    Off,
+}
+
+impl From<RuntimePowerManagement> for &'static str {
+    fn from(pm: RuntimePowerManagement) -> &'static str {
+        match pm {
+            RuntimePowerManagement::On => "auto",
+            RuntimePowerManagement::Off => "on",
+        }
+    }
 }
 
 pub struct Dirty {

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -1,5 +1,6 @@
 use std::{fs, io, u8, u16, u32};
 use std::path::{Path, PathBuf};
+use kernel_parameters::RuntimePowerManagement;
 
 use util::{entries, read_file, write_file};
 
@@ -81,6 +82,11 @@ impl PciDevice {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    pub fn set_runtime_pm(&self, state: RuntimePowerManagement) -> io::Result<()> {
+        let state: &'static str = state.into();
+        write_file(&self.path.join("power/control"), state)
     }
 
     pci_device!(class as u32);


### PR DESCRIPTION
With this, PowerTop will report that we're setting good values for all of the reported tunables on the battery profile, except for USB autosuspend, which I don't think we want.