### PR TITLE
Rewrite the dbus impl macro

### DIFF
--- a/src/daemon_macro.rs
+++ b/src/daemon_macro.rs
@@ -1,0 +1,66 @@
+// Defines whether the value returned by the method should be appended.
+macro_rules! append {
+    (has_out, $m:ident, $value:ident) => {
+        $m.msg.method_return().append1($value)
+    };
+
+    (no_out, $m:ident, $value:ident) => {
+        $m.msg.method_return()
+    };
+}
+
+// Programs the message that should be printed.
+macro_rules! get_value {
+    (has_in, $name:expr, $daemon:ident, $m:ident, $method:tt) => {{
+        let value = $m.msg.read1()?;
+        info!("DBUS Received {}({}) method", $name, value);
+        $daemon.borrow_mut().$method(value)
+    }};
+
+    (no_in, $name:expr, $daemon:ident, $m:ident, $method:tt) => {{
+        info!("DBUS Received {} method", $name);
+        $daemon.borrow_mut().$method()
+    }};
+}
+
+#[macro_export]
+macro_rules! dbus_impl {
+    ($daemon:expr, $f:ident {
+        $(
+            fn $method:tt<$name:tt, $append:tt, $hasvalue:tt>(
+                $( $inarg_name:tt : $inarg_type:ty ),*
+            ) $( -> $($outarg_name:tt: $outarg_type:ty ),* )*;
+        )*
+
+        $(
+            signal $signal:ident;
+        )*
+    }) => {{
+        let interface = $f.interface(DBUS_IFACE, ())
+            $(
+                .add_m({
+                    let daemon = $daemon.clone();
+                    $f.method(stringify!($name), (), move |m| {
+                        let result = get_value!($hasvalue, stringify!($name), daemon, m, $method);
+                        match result {
+                            Ok(_value) => {
+                                let mret = append!($append, m, _value);
+                                Ok(vec![mret])
+                            }
+                            Err(err) => {
+                                error!("{}", err);
+                                Err(MethodErr::failed(&err))
+                            }
+                        }
+                    })
+                    $(.inarg::<$inarg_type, _>(stringify!($inarg_name)))*
+                    $($(.outarg::<$outarg_type, _>(stringify!($outarg_name)))*)*
+                })
+            )*
+            $(
+                .add_s($signal.clone())
+            )*;
+
+        $f.tree(()).add($f.object_path(DBUS_PATH, ()).introspectable().add(interface))
+    }}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ extern crate libc;
 extern crate log;
 extern crate sysfs_class;
 
+#[macro_use]
+mod daemon_macro;
+
 pub mod client;
 pub mod daemon;
 pub mod disks;


### PR DESCRIPTION
I'm going to split #42 into multiple smaller, incremental PRs.

This changes the dbus macro rules to be more flexible, and a bit more maintainable.

```rust
let f = Factory::new_fn::<()>();

let signal_hotplug = Arc::new(f.signal("HotPlugDetect", ()).sarg::<u64, _>("port"));

let tree = dbus_impl!(daemon, f {
    // Power Profiles
    fn battery<Battery, no_out, no_in>();
    fn balanced<Balanced, no_out, no_in>();
    fn performance<Performance, no_out, no_in>();

    // Graphics
    fn get_graphics<GetGraphics, has_out, no_in>() -> vendor: &str;
    fn set_graphics<SetGraphics, no_out, has_in>(vendor: &str);
    fn get_graphics_power<GetGraphicsPower, has_out, no_in>() -> power: bool;
    fn set_graphics_power<SetGraphicsPower, no_out, has_in>(power: bool);
    fn auto_graphics_power<AutoGraphicsPower, no_out, no_in>();

    // Switchable graphics detection
    fn get_switchable<GetSwitchable, has_out, no_in>() -> switchable: bool;

    signal signal_hotplug;
});
```

```rust
fn get_graphics<GetGraphics, has_out, no_in>() -> vendor: &str;
```

This defines that a method named `get_graphics` exists in the `daemon`. It will be assigned to a dbus method named `GetGraphics`. The `no_out`/`has_out` and `no_in`/`has_in` keywords can be removed in the latest stable version of rustc, but for now state whether the method has input / output arguments.

In the case of `-> vendor: &str`, it defines that the dbus method returns a dbus `s` output named `vendor`. `(vendor: &str)` defines that it takes a dbus `s` input, named `vendor`. It's possible to write `(param1: &str, param2: &str)` to have a `(ss)` input, or `-> param1: &str, param2: &str` to have a `(ss)` output, and thus it's possible to mix and match types.

```rust
signal signal_hotplug;
```

This registers the `signal_hotplug` signal created earlier with the daemon. The macro could be expanded to have a similar syntax for defining signals, but I don't think that will be necessary, since we don't have very many signals.