### PR TITLE
Add darp6 and galp4 to automatic display switching

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,10 @@ CLEAN ?= 1
 %:
 	dh $@ --with=systemd
 
+override_dh_auto_build:
+	env CARGO_HOME="$$(pwd)/target/cargo" \
+	dh_auto_build
+
 override_dh_auto_clean:
 ifeq ($(CLEAN),1)
 	make clean

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -33,7 +33,7 @@ impl DisplayPortMux {
                 hpd:      (0xAE, 0x31), // GPP_E13
                 mux:      (0xAF, 0x16), // GPP_A22
             }),
-            "darp5" | "galp3-c" => Ok(DisplayPortMux {
+            "darp5" | "darp6" | "galp3-c" | "galp4" => Ok(DisplayPortMux {
                 sideband: Sideband::new(0xFD00_0000)?,
                 hpd:      (0x6A, 0x4A), // GPP_E13
                 mux:      (0x6E, 0x2C), // GPP_A22


### PR DESCRIPTION
This is on the coreboot branch to allow it to install all required features