### PR TITLE
Switch graphics mode without reboot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Replaces: nvidia-prime
 Depends:
   dbus,
   systemd,
+  ubuntu-drivers-common,
   ${misc:Depends},
   ${shlib:Depends}
 Description: System76 Power Management

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -275,6 +275,22 @@ impl Graphics {
 
         const SYSTEMCTL_CMD: &str = "systemctl";
 
+        // NVIDIA driver functions are still in use, so we can't turn off power
+        // yet if switching to Intel.
+        if vendor == "nvidia" || vendor == "hybrid" {
+            self.set_power(true)?;
+        }
+
+        let status = process::Command::new(SYSTEMCTL_CMD)
+            .arg("restart")
+            .arg("gpu-manager.service")
+            .status()
+            .map_err(|why| GraphicsDeviceError::Command { cmd: SYSTEMCTL_CMD, why })?;
+
+        if !status.success() {
+            warn!("Unable to restart gpu-manager: {}", status);
+        }
+
         let action = if vendor == "nvidia" {
             info!("Enabling nvidia-fallback.service");
             "enable"


### PR DESCRIPTION
By further utilizing gpu-manager, we can perform most operations for switching graphics modes without requiring a reboot.

In order for switching and runpm to work correctly, GDM must be restarted. This will end all running GNOME sessions.

    system76-power graphics <mode>
    systemctl restart display-manager

See: #57