### PR TITLE
Update fan tests, fix fan example

### DIFF
--- a/examples/fan.rs
+++ b/examples/fan.rs
@@ -9,7 +9,7 @@ use system76_power::{
 };
 
 fn inner() -> Result<(), FanDaemonError> {
-    let daemon = FanDaemon::new(false)?;
+    let daemon = FanDaemon::new(false);
 
     loop {
         if let Some(temp) = daemon.get_temp() {

--- a/src/fan.rs
+++ b/src/fan.rs
@@ -303,16 +303,13 @@ mod tests {
     fn standard_points() {
         let standard = FanCurve::standard();
 
-        assert_eq!(standard.get_duty(0), Some(3000));
-        assert_eq!(standard.get_duty(1000), Some(3000));
-        assert_eq!(standard.get_duty(2000), Some(3000));
-        assert_eq!(standard.get_duty(3000), Some(3500));
-        assert_eq!(standard.get_duty(4000), Some(4250));
-        assert_eq!(standard.get_duty(5000), Some(5250));
-        assert_eq!(standard.get_duty(6000), Some(8417));
-        assert_eq!(standard.get_duty(7000), Some(10000));
-        assert_eq!(standard.get_duty(8000), Some(10000));
-        assert_eq!(standard.get_duty(9000), Some(10000));
+        assert_eq!(standard.get_duty(0), Some(0));
+        assert_eq!(standard.get_duty(3999), Some(0));
+        assert_eq!(standard.get_duty(4000), Some(4000));
+        assert_eq!(standard.get_duty(5000), Some(5000));
+        assert_eq!(standard.get_duty(6000), Some(6500));
+        assert_eq!(standard.get_duty(7000), Some(8500));
+        assert_eq!(standard.get_duty(7500), Some(10000));
         assert_eq!(standard.get_duty(10000), Some(10000));
     }
 }


### PR DESCRIPTION
```
$ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s                                                                  
     Running target/debug/deps/system76_power-ff7e65f7453a8667

running 2 tests
test fan::tests::duty_interpolation ... ok
test fan::tests::standard_points ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/system76_power-fac996b91dc797ca

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests system76-power

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```