### PR TITLE
Log caught signals as errors

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -30,7 +30,7 @@ static CONTINUE: AtomicBool = AtomicBool::new(true);
 
 fn signal_handling() {
     extern "C" fn handler(signal: libc::c_int) {
-        info!("caught signal: {}", signal);
+        error!("caught signal: {}", signal);
         CONTINUE.store(false, Ordering::SeqCst);
     }
 


### PR DESCRIPTION
These are not part of normal process flow and indicate something has gone wrong. Log them higher to make them easier to identify.