### PR TITLE
Add XEON fan curve and setup thelio-massive-b1 to use it.

### DIFF
--- a/src/fan.rs
+++ b/src/fan.rs
@@ -32,6 +32,7 @@ impl FanDaemon {
             curve: match model.trim() {
                 "thelio-major-r1" => FanCurve::threadripper(),
                 "thelio-major-b1" => FanCurve::corex(),
+                "thelio-massive-b1" => FanCurve::xeon(),
                 _ => FanCurve::standard()
             },
             amdgpus: Vec::new(),
@@ -248,6 +249,22 @@ impl FanCurve {
             .append(66_25, 100_00)
     }
 
+    /// Adjusted fan curve for xeon
+    pub fn xeon() -> Self {
+        Self::default()
+            .append(00_00,  40_00)
+            .append(50_00,  40_00)
+            .append(55_00,  45_00)
+            .append(60_00,  50_00)
+            .append(65_00,  55_00)
+            .append(70_00,  60_00)
+            .append(75_00,  65_00)
+            .append(78_00,  80_00)
+            .append(81_00,  85_00)
+            .append(83_00,  90_00)
+            .append(85_00, 100_00)
+    }
+
     pub fn get_duty(&self, temp: i16) -> Option<u16> {
         // If the temp is less than the first point, return the first point duty
         if let Some(first) = self.points.first() {
@@ -338,6 +355,24 @@ mod tests {
         assert_eq!(corex.get_duty(6500), Some(6500));
         assert_eq!(corex.get_duty(7500), Some(8500));
         assert_eq!(corex.get_duty(8000), Some(10000));
+        assert_eq!(corex.get_duty(10000), Some(10000));
+    }
+
+    #[test]
+    fn xeon_points() {
+        let xeon = FanCurve::xeon();
+
+        assert_eq!(corex.get_duty(0), Some(4000));
+        assert_eq!(corex.get_duty(5000), Some(4000));
+        assert_eq!(corex.get_duty(5500), Some(4500));
+        assert_eq!(corex.get_duty(6000), Some(5000));
+        assert_eq!(corex.get_duty(6500), Some(5500));
+        assert_eq!(corex.get_duty(7000), Some(6000));
+        assert_eq!(corex.get_duty(7500), Some(6500));
+        assert_eq!(corex.get_duty(7800), Some(8000));
+        assert_eq!(corex.get_duty(8100), Some(8500));
+        assert_eq!(corex.get_duty(8300), Some(9000));
+        assert_eq!(corex.get_duty(8500), Some(10000));
         assert_eq!(corex.get_duty(10000), Some(10000));
     }
 }


### PR DESCRIPTION
Testing completed with dual XEON Gold 6248 CPUs and quad nvidia RTX 2080 Super Blowers. At idle, the CPU require a fan duty load of 40 to dissipate produced heat. At a 90 duty cycle, the thermal system dissipates CPU heat when fully stressed.

GPUs begin to throttle at 87 degrees. The fan curve increases fan speed to 100% at 85 degrees to limit GPU throttling.

Acoustic results

Test | Decibels | Diff
----- | ------------ | -----
Idle  | 33.45 | -7.2
CPU Stress Result | 39.3 | -5.9
GPU Stress | 55.45 | -2.3
CPU+GPU Stress Result | 55.15 | -2.6