### PR TITLE
fix(TESTING.md&&Makefile): The cmd about 'graphics power state' in TESTING.md is wrong.Fix the problem of missing .service file after make install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,12 @@ distclean:
 install: all
 	install -D -m 04755 "target/release/$(BIN)" "$(DESTDIR)$(bindir)/$(BIN)"
 	install -D -m 0644 "data/$(BIN).conf" "$(DESTDIR)$(sysconfdir)/dbus-1/system.d/$(BIN).conf"
+	install -D -m 0644 "debian/$(BIN).service" "$(DESTDIR)$(sysconfdir)/systemd/system/$(BIN).service"
 
 uninstall:
 	rm -f "$(DESTDIR)$(bindir)/$(BIN)"
 	rm -f "$(DESTDIR)$(sysconfdir)/dbus-1/system.d/$(BIN).conf"
+	rm -f "$(DESTDIR)$(sysconfdir)/systemd/system/$(BIN).service"
 
 update:
 	cargo update

--- a/TESTING.md
+++ b/TESTING.md
@@ -96,9 +96,9 @@ Instructions for interacting with features for first-time testers.
     ```
 - Query discrete graphics power state
     ```sh
-    ssytem76-power graphics power
+    system76-power graphics power
     ```
 - Set discrete graphics power state
     ```sh
-    ssytem76-power graphics power [ on | off]
+    system76-power graphics power [ on | off]
     ```


### PR DESCRIPTION
* The cmd about 'graphics power state' in TESTING.md is wrong.
  * Query discrete graphics power state: system76-power graphics power
  * Set discrete graphics power state:  system76-power graphics power [ on | off]
* In Makefile, I suggest that the cmd about the .service file should be added in make [install | uninstall] 