### PR TITLE
feat: Methods for getting/setting keyboard backlight colors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use crate::{err_str, Power, DBUS_IFACE, DBUS_NAME, DBUS_PATH};
 use clap::ArgMatches;
 use dbus::{arg::Append, ffidisp::Connection, Message};
 use pstate::PState;
+use std::collections::HashMap;
 use std::io;
 use sysfs_class::{Backlight, Brightness, Leds, SysClass};
 
@@ -89,6 +90,15 @@ impl Power for PowerClient {
     fn auto_graphics_power(&mut self) -> Result<(), String> {
         println!("setting discrete graphics to turn off when not in use");
         self.call_method::<bool>("AutoGraphicsPower", None).map(|_| ())
+    }
+
+    fn get_keyboard_colors(&mut self) -> Result<HashMap<String, String>, String> {
+        let r = self.call_method::<HashMap<String, String>>("GetKeyboardColors", None)?;
+        r.get1().ok_or_else(|| "return value not found".to_string())
+    }
+
+    fn set_keyboard_colors(&mut self, colors: HashMap<String, String>) -> Result<(), String> {
+        self.call_method::<HashMap<String, String>>("SetKeyboardColors", Some(colors)).map(|_| ())
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,12 +8,12 @@ use sysfs_class::{Backlight, Brightness, Leds, SysClass};
 
 static TIMEOUT: i32 = 60 * 1000;
 
-struct PowerClient {
+pub struct PowerClient {
     bus: Connection,
 }
 
 impl PowerClient {
-    fn new() -> Result<PowerClient, String> {
+    pub fn new() -> Result<PowerClient, String> {
         let bus = Connection::new_system().map_err(err_str)?;
         Ok(PowerClient { bus })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ extern crate intel_pstate as pstate;
 #[macro_use]
 extern crate log;
 
+use std::collections::HashMap;
+
 pub mod client;
 pub mod daemon;
 pub mod disks;
@@ -40,6 +42,8 @@ pub trait Power {
     fn get_graphics_power(&mut self) -> Result<bool, String>;
     fn set_graphics_power(&mut self, power: bool) -> Result<(), String>;
     fn auto_graphics_power(&mut self) -> Result<(), String>;
+    fn get_keyboard_colors(&mut self) -> Result<HashMap<String, String>, String>;
+    fn set_keyboard_colors(&mut self, colors: HashMap<String, String>) -> Result<(), String>;
 }
 
 // Helper function for errors


### PR DESCRIPTION
This should help with implementing https://github.com/pop-os/gnome-control-center/issues/102.

So far I haven't updated the CLI to support this. I'm not sure exactly what interface we would want there.