### PR TITLE
improv: Use anyhow::Error instead of String for error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +384,7 @@ dependencies = [
 name = "system76-power"
 version = "1.1.10"
 dependencies = [
+ "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -489,6 +495,7 @@ dependencies = [
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1"
 dbus = "0.8.4"
 libc = "0.2.76"
 clap = "2.33.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ extern crate intel_pstate as pstate;
 #[macro_use]
 extern crate log;
 
+use anyhow::Result;
+
 pub mod client;
 pub mod daemon;
 pub mod disks;
@@ -31,17 +33,14 @@ pub static DBUS_PATH: &'static str = "/com/system76/PowerDaemon";
 pub static DBUS_IFACE: &'static str = "com.system76.PowerDaemon";
 
 pub trait Power {
-    fn performance(&mut self) -> Result<(), String>;
-    fn balanced(&mut self) -> Result<(), String>;
-    fn battery(&mut self) -> Result<(), String>;
-    fn get_graphics(&mut self) -> Result<String, String>;
-    fn get_profile(&mut self) -> Result<String, String>;
-    fn get_switchable(&mut self) -> Result<bool, String>;
-    fn set_graphics(&mut self, vendor: &str) -> Result<(), String>;
-    fn get_graphics_power(&mut self) -> Result<bool, String>;
-    fn set_graphics_power(&mut self, power: bool) -> Result<(), String>;
-    fn auto_graphics_power(&mut self) -> Result<(), String>;
+    fn performance(&mut self) -> Result<()>;
+    fn balanced(&mut self) -> Result<()>;
+    fn battery(&mut self) -> Result<()>;
+    fn get_graphics(&mut self) -> Result<String>;
+    fn get_profile(&mut self) -> Result<String>;
+    fn get_switchable(&mut self) -> Result<bool>;
+    fn set_graphics(&mut self, vendor: &str) -> Result<()>;
+    fn get_graphics_power(&mut self) -> Result<bool>;
+    fn set_graphics_power(&mut self, power: bool) -> Result<()>;
+    fn auto_graphics_power(&mut self) -> Result<()>;
 }
-
-// Helper function for errors
-pub(crate) fn err_str<E: ::std::fmt::Display>(err: E) -> String { format!("{}", err) }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Error;
 use clap::{App, AppSettings, Arg, SubCommand};
 use log::LevelFilter;
 use std::process;
@@ -101,7 +102,7 @@ fn main() {
             if unsafe { libc::geteuid() } == 0 {
                 daemon::daemon()
             } else {
-                Err("must be run as root".to_string())
+                Err(Error::msg("must be run as root"))
             }
         }
         (subcommand, Some(matches)) => client::client(subcommand, matches),


### PR DESCRIPTION
This is generally a better practice. It seems to make the code slightly neater, or comparable.

BREAKING CHANGE: This changes the public API of the crate. However, it shouldn't change the behavior of the program other than somewhat different error messages for crashes.