### PR TITLE
fix(Makefile): Do not set setuid bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ distclean:
 	rm -rf .cargo vendor vendor.tar.xz
 
 install: all
-	install -D -m 04755 "target/release/$(BIN)" "$(DESTDIR)$(bindir)/$(BIN)"
+	install -D -m 0755 "target/release/$(BIN)" "$(DESTDIR)$(bindir)/$(BIN)"
 	install -D -m 0644 "data/$(BIN).conf" "$(DESTDIR)$(sysconfdir)/dbus-1/system.d/$(BIN).conf"
 	install -D -m 0644 "debian/$(BIN).service" "$(DESTDIR)$(sysconfdir)/systemd/system/$(BIN).service"
 


### PR DESCRIPTION
Not sure if this made sense at one point, but it doesn't seem to be relevant now. This also doesn't seem to be set when installed from the .deb, so this change should have no effect on the built package.

Fixes https://github.com/pop-os/system76-power/issues/174