### PR TITLE
Report default graphics as integrated if checking RTD3 support fails

### DIFF
--- a/data/system76-power.conf
+++ b/data/system76-power.conf
@@ -15,4 +15,8 @@
         <allow send_destination="com.system76.PowerDaemon"/>
         <allow receive_sender="com.system76.PowerDaemon"/>
     </policy>
+    <policy user="gnome-initial-setup">
+        <allow send_destination="com.system76.PowerDaemon"/>
+        <allow receive_sender="com.system76.PowerDaemon"/>
+    </policy>
 </busconfig>

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -312,6 +312,10 @@ impl Graphics {
             .map(|s| s.trim().to_string())?;
         let blacklisted = DEFAULT_INTEGRATED.contains(&product.as_str());
 
+        // If the NVIDIA device is not on the bus or the drivers are not
+        // loaded, then assume runtimepm is not supported.
+        let runtimepm = self.gpu_supports_runtimepm().unwrap_or_default();
+
         // Only default to hybrid on System76 models
         let vendor = fs::read_to_string("/sys/class/dmi/id/sys_vendor")
             .map_err(GraphicsDeviceError::SysFs)
@@ -319,7 +323,7 @@ impl Graphics {
 
         if vendor != "System76" {
             Ok("nvidia".to_string())
-        } else if self.gpu_supports_runtimepm()? && !blacklisted {
+        } else if runtimepm && !blacklisted {
             Ok("hybrid".to_string())
         } else {
             Ok("integrated".to_string())


### PR DESCRIPTION
If the NVIDIA device is not on the bus or the drivers are not loaded, assume run-time power management is not supported.

Tested with pop-os/gnome-initial-setup#68.

Fixes: 8959756fee2 ("Determine default graphics by runtimepm support")