### PR TITLE
test using 'cargo' action instead of 'clippy-check'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           profile: minimal
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: actions-rs/cargo@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          command: clippy
+          args: --all --all-features

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,24 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  clippy:
+  clippy-check:
     name: Clippy Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: install system dependencies
+        run: sudo apt-get install libdbus-1-dev libusb-1.0-0-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all --all-features
+
+  cargo-clippy:
+    name: Cargo Clippy
     runs-on: ubuntu-latest
     steps:
       - name: install system dependencies


### PR DESCRIPTION
i've used the 'clippy-check' action instead of the 'cargo' action in the github workflow because the 'clippy-check' action is supposed to be able to comment inline on pull requests.

that doesn't work on pull requests from forks, which is a major limitation. however this *did* work in the 'test' action in #233, which is surprising.

i've created this draft pull request to compare the two actions