### PR TITLE
add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,4 +28,4 @@ jobs:
           args: --all-features
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: Code Coverage
+
+jobs:
+  coverage:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: install system dependencies
+        run: sudo apt-get install libdbus-1-dev libusb-1.0-0-dev
+
+      - name: checkout source
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: --all-features
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
closes #237

the coverage of this repo is low, but that doesn't mean coverage testing isn't useful. it provides a mechanism for ensuring that coverage at least improves over time