### PR TITLE
Make xeon fan curve more aggressive

### DIFF
--- a/src/fan.rs
+++ b/src/fan.rs
@@ -271,13 +271,12 @@ impl FanCurve {
             .append(50_00, 40_00)
             .append(55_00, 45_00)
             .append(60_00, 50_00)
-            .append(65_00, 55_00)
-            .append(70_00, 60_00)
-            .append(72_00, 65_00)
-            .append(74_00, 80_00)
-            .append(76_00, 85_00)
-            .append(77_00, 90_00)
-            .append(78_00, 100_00)
+            .append(62_00, 60_00)
+            .append(64_00, 65_00)
+            .append(66_00, 80_00)
+            .append(68_00, 85_00)
+            .append(69_00, 90_00)
+            .append(70_00, 100_00)
     }
 
     pub fn get_duty(&self, temp: i16) -> Option<u16> {


### PR DESCRIPTION
I've been suffering from occasional power offs with no warning, and I
suspect the CPU is getting too hot.  On the most recent power off, the
computer once again powered down during the bootup phase (before the EFI
boot screen).  To me this solidified my suspicions.

I have a a thelio-massive-b1 with 2
Intel(R) Xeon(R) Gold 6238 CPU @ 2.10GHz

I patched the source making the xeon fan curve more aggressive and the
maximum CPU temperatures are now a little lower.  Under low system load
there is no noticable difference in fan speed.

Plots of CPU temperature, fan speed, and fan command are attached as
comments to the commit on GitHub.

Signed-off-by: Erich Ritz <erich.public@protonmail.com>