### PR TITLE
Disable dGPU in integrated mode if it doesn't support runtimepm

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -233,11 +233,11 @@ pub async fn daemon() -> Result<(), String> {
         None
     };
 
-    log::info!("Setting graphics power");
-    match daemon.set_graphics_power(true) {
+    log::info!("Setting automatic graphics power");
+    match daemon.auto_graphics_power() {
         Ok(()) => (),
         Err(err) => {
-            log::warn!("Failed to set graphics power: {}", err);
+            log::warn!("Failed to set automatic graphics power: {}", err);
         }
     }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -521,8 +521,12 @@ impl Graphics {
     }
 
     pub fn auto_power(&self) -> Result<(), GraphicsDeviceError> {
+        // Only disable power if in integrated mode and the device does not
+        // support runtime power management.
         let vendor = self.get_vendor()?;
-        self.set_power(vendor != GraphicsMode::Integrated)
+        let power = vendor != GraphicsMode::Integrated || self.gpu_supports_runtimepm()?;
+
+        self.set_power(power)
     }
 
     fn switchable_or_fail(&self) -> Result<(), GraphicsDeviceError> {


### PR DESCRIPTION
If a device does not support runtime power management, then remove it from the bus when in integrated mode.

Fixes: 1e1599a9dd12 ("daemon: Always enable GPU power")
Resolves: #325