### PR TITLE
chore: Add system76-power.service as an alias

### DIFF
--- a/data/com.system76.PowerDaemon.service
+++ b/data/com.system76.PowerDaemon.service
@@ -9,3 +9,4 @@ BusName=com.system76.PowerDaemon
 
 [Install]
 WantedBy=multi-user.target
+Alias=system76-power.service

--- a/debian/system76-power.com.system76.PowerDaemon.service
+++ b/debian/system76-power.com.system76.PowerDaemon.service
@@ -9,3 +9,4 @@ BusName=com.system76.PowerDaemon
 
 [Install]
 WantedBy=multi-user.target
+Alias=system76-power.service

--- a/debian/system76-power.postinst
+++ b/debian/system76-power.postinst
@@ -2,6 +2,8 @@
 
 set -e
 
+systemctl enable com.system76.PowerDaemon
+
 case "$1" in
     configure)
         rm -f /etc/modules-load.d/system76-power.conf


### PR DESCRIPTION
Installs the service with both names so they're addressable either way.