### PR TITLE
Revert "daemon: Always enable GPU power" 

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -233,11 +233,11 @@ pub async fn daemon() -> Result<(), String> {
         None
     };
 
-    log::info!("Setting graphics power");
-    match daemon.set_graphics_power(true) {
+    log::info!("Setting automatic graphics power");
+    match daemon.auto_graphics_power() {
         Ok(()) => (),
         Err(err) => {
-            log::warn!("Failed to set graphics power: {}", err);
+            log::warn!("Failed to set automatic graphics power: {}", err);
         }
     }
 


### PR DESCRIPTION
oryp4 doesn't behave correctly with the GPU enabled in integrated mode because it doesn't support RTD3.

Revert the change that left the GPU always enabled, and cherry-pick the change to get supported features while in integrated mode.

Fixes: #325 