### PR TITLE
Drop dependency on ubuntu-drivers-common

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,6 @@ Replaces: nvidia-prime
 Depends:
   dbus,
   systemd,
-  ubuntu-drivers-common,
   ${misc:Depends},
   ${shlibs:Depends}
 Description: System76 Power Management


### PR DESCRIPTION
With runtimepm and X configuration implmented, system76-power no longer
relies on behavior from gpu-manager.

gpu-manager should be disabled when using system76-power.

Resolves: #291
Ref: pop-os/ubuntu-drivers-common#20