### PR TITLE
Add profile information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ is made available as a compute node.
 ### Battery
 
 - Uses settings from Performance
-- Sets Screen brightness and keyboard brightness to lower values 
+- Sets Screen brightness to a lower value
+- Turns keyboard backlight off
 
 ## Hotplug detection
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ $ jq '.chips[] | select(.devid=="0x1F15")' < /usr/share/doc/nvidia-driver-460/su
 The integrated graphics controller is used exclusively for rendering. The dGPU
 is made available as a compute node.
 
+## Power Profiles
+
+### Balanced
+
+- Set the sync data to disk to 15s
+- Enables laptop mode feature in kernel
+- Enables SCSI/SATA link time power management
+- Controls the Intel PState values if they exist
+
+### Performance
+
+### Battery
+
 ## Hotplug detection
 
 The dbus signal `HotPlugDetect` is sent when a display is plugged into a port

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ is made available as a compute node.
 
 ### Performance
 
+- Uses settings from Balanced
+- Uses ACPI Platform profile is the hardware is supported by the kernel
+
 ### Battery
+
+- Uses settings from Performance
+- Sets Screen brightness and keyboard brightness to lower values 
 
 ## Hotplug detection
 

--- a/src/daemon/profiles.rs
+++ b/src/daemon/profiles.rs
@@ -42,7 +42,7 @@ pub fn balanced(errors: &mut Vec<ProfileError>, set_brightness: bool) {
 
     // The dirty kernel parameter controls how often the OS will sync data to disks. The less
     // frequently this occurs, the more power can be saved, yet the higher the risk of sudden
-    // power loss causing loss of data. 15s is a resonable number.
+    // power loss causing loss of data. 15s is a reasonable number.
     Dirty::default().set_max_lost_work(15);
 
     // Enables the laptop mode feature in the kernel, which allows mechanical drives to spin down


### PR DESCRIPTION
This PR does the following:

- Adds information about Power Profiles to the README based on comments in src/daemon/profile.rs
- Fixes a typo in a comment in that source file