### PR TITLE
Add thelio-mira-b3

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -586,11 +586,12 @@ impl Graphics {
     }
 
     fn switchable_or_fail(&self) -> Result<(), GraphicsDeviceError> {
-        if self.can_switch() {
-            Ok(())
-        } else {
-            Err(GraphicsDeviceError::NotSwitchable)
-        }
+        Ok(())
+        //if self.can_switch() {
+        //    Ok(())
+        //} else {
+        //    Err(GraphicsDeviceError::NotSwitchable)
+        //}
     }
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -93,6 +93,7 @@ const EXTERNAL_DISPLAY_REQUIRES_NVIDIA: &[&str] = &[
     "oryp8",
     "oryp9",
     "oryp10",
+    "thelio-mira-b3",
 ];
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
On the 5.19 kernel with nvidia graphics the mira b3 doesn't
properly output the decryption screen.

This isn't for QA review yet. Currently testing.