### PR TITLE
Add check for thelio to get_default_graphics

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -392,6 +392,7 @@ impl Graphics {
             .map_err(GraphicsDeviceError::SysFs)
             .map(|s| s.trim().to_string())?;
         let blacklisted = DEFAULT_INTEGRATED.contains(&product.as_str());
+        let thelio = product.contains("thelio");
 
         let runtimepm = self.gpu_supports_runtimepm().unwrap_or_default();
 
@@ -400,7 +401,7 @@ impl Graphics {
             .map_err(GraphicsDeviceError::SysFs)
             .map(|s| s.trim().to_string())?;
 
-        if vendor != "System76" {
+        if (vendor != "System76") || thelio {
             Ok(GraphicsMode::Discrete)
         } else if runtimepm && !blacklisted {
             Ok(GraphicsMode::Hybrid)


### PR DESCRIPTION
Checks to see if the system is a thelio in get_default_graphics and enables hybrid graphics if true. This fixes [issue #370 ](https://github.com/pop-os/system76-power/issues/370)