### PR TITLE
graphics: Do not report desktops as switchable

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -318,9 +318,18 @@ impl Graphics {
         Ok(Graphics { bus, amd, intel, nvidia, other })
     }
 
+    pub fn is_desktop(&self) -> bool {
+        let chassis = fs::read_to_string("/sys/class/dmi/id/chassis_type")
+            .map_err(GraphicsDeviceError::SysFs)
+            .unwrap_or_default();
+
+        chassis.trim() == "3"
+    }
+
     #[must_use]
     pub fn can_switch(&self) -> bool {
-        !self.nvidia.is_empty() && (!self.intel.is_empty() || !self.amd.is_empty())
+        !self.is_desktop()
+            && (!self.nvidia.is_empty() && (!self.intel.is_empty() || !self.amd.is_empty()))
     }
 
     pub fn get_external_displays_require_dgpu(&self) -> Result<bool, GraphicsDeviceError> {


### PR DESCRIPTION
Desktops should not report as switchable if they have a dGPU. The switchable graphics mechanisms are designed for notebook systems.

The physical selection of ports the *user* chooses when plugging in displays determines whether the iGPU or the dGPU will be used.

### Test

- Desktop reports "not switchable" when queried
- gnome-initial-setup does not show the panel about switchable graphics on desktops
- Display output works when plugged into iGPU ports
- Display output works when plugged into dGPU ports
- dGPU can be used as a compute node when displays are plugged into the iGPU ports