### PR TITLE
fix: Disable runtime PM for PCI and I2C devices

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -249,16 +249,6 @@ pub async fn daemon() -> Result<(), String> {
 
     daemon.initial_set = true;
 
-    log::info!("Enabling runtime PM for I2C adapters");
-    for device in crate::sys_devices::i2c::devices() {
-        device.set_runtime_pm(sysfs_class::RuntimePowerManagement::On);
-    }
-
-    log::info!("Enabling runtime PM for PCI devices");
-    for device in crate::sys_devices::pci::devices() {
-        device.set_runtime_pm(sysfs_class::RuntimePowerManagement::On);
-    }
-
     log::info!("Registering dbus name {}", DBUS_NAME);
     c.request_name(DBUS_NAME, false, true, false).await.map_err(err_str)?;
 


### PR DESCRIPTION
Some people are saying that they're having issues after a recent update.  With system76-power being one of these recent updates, this might be the cause. It'd be good if we could get some people with the issues to test this change to see if it's the cause.

- https://www.reddit.com/r/pop_os/comments/zsgw5m/borked_update/
- https://www.reddit.com/r/pop_os/comments/zsawod/did_everyone_get_their_screwed_up_systems_fixed/
- https://www.reddit.com/r/pop_os/comments/zrm6kp/games_freezing_after_latest_system_updates/
- https://www.reddit.com/r/pop_os/comments/zreyvt/pop_os_2204_wired_ethernet_stops_working_after/
- https://www.reddit.com/r/pop_os/comments/zrfxbc/pop_os_2204_has_issues_after_updating_steam_wont/
- https://www.reddit.com/r/pop_os/comments/zrnpzl/hanging_shutdowns/

One person mentioned an issue [shutting down a Thelio](https://www.reddit.com/r/pop_os/comments/zs7net/comment/j178w27/).

It could have also been a past kernel update. Depends when the last time the person updated and restarted.