### PR TITLE
Add new models

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -76,6 +76,8 @@ const PRIME_DISCRETE_PATH: &str = "/etc/prime-discrete";
 const EXTERNAL_DISPLAY_REQUIRES_NVIDIA: &[&str] = &[
     "addw1",
     "addw2",
+    "addw3",
+    "bonw15",
     "gaze14",
     "gaze15",
     "gaze16-3050",
@@ -92,6 +94,8 @@ const EXTERNAL_DISPLAY_REQUIRES_NVIDIA: &[&str] = &[
     "oryp8",
     "oryp9",
     "oryp10",
+    "oryp11",
+    "serw13",
 ];
 
 const SYSTEMCTL_CMD: &str = "systemctl";

--- a/src/hotplug/mod.rs
+++ b/src/hotplug/mod.rs
@@ -128,6 +128,30 @@ impl HotPlugDetect {
                     ],
                 }),
             }),
+            "addw3" => Ok(Self {
+                integrated: Integrated::Intel(Intel {
+                    sideband: Sideband::new(0xE000_0000)?,
+                    port:     0x6E,
+                    pins:     [
+                        0x04, // Mini DisplayPort
+                        0x08, // HDMI
+                        0x00, // TODO: USB-C?
+                        0x00, // Not connected
+                    ],
+                }),
+            }),
+            "bonw15" => Ok(Self {
+                integrated: Integrated::Intel(Intel {
+                    sideband: Sideband::new(0xE000_0000)?,
+                    port:     0x6E,
+                    pins:     [
+                        0x02, // Mini DisplayPort
+                        0x06, // HDMI
+                        0x00, // TODO: USB-C?
+                        0x00, // Not connected
+                    ],
+                }),
+            }),
             "gaze14" => {
                 let variant =
                     fs::read_to_string("/sys/bus/pci/devices/0000:00:00.0/subsystem_device")
@@ -295,6 +319,30 @@ impl HotPlugDetect {
                         0x78, // HDMI
                         0x7C, // USB-C
                         0x00, // Not Connected
+                    ],
+                }),
+            }),
+            "oryp11" => Ok(Self {
+                integrated: Integrated::Intel(Intel {
+                    sideband: Sideband::new(PCR_BASE_ADDRESS)?,
+                    port:     0x6E,
+                    pins:     [
+                        0x72, // Mini DisplayPort
+                        0x78, // HDMI
+                        0x00, // TODO: USB-C?
+                        0x00, // Not connected
+                    ],
+                }),
+            }),
+            "serw13" => Ok(Self {
+                integrated: Integrated::Intel(Intel {
+                    sideband: Sideband::new(0xE000_0000)?,
+                    port:     0x6E,
+                    pins:     [
+                        0x00, // FIXME: USB-C is pin 0, but also doesn't work
+                        0x00, // TBT connected to iGPU
+                        0x04, // HDMI
+                        0x08, // Mini DisplayPort
                     ],
                 }),
             }),


### PR DESCRIPTION
- gaze18: All display ports are connected to the iGPU
- serw13: mDP over USB-C doesn't seem to work on proprietary firmware