### PR TITLE
Fixes for NVIDIA suspend on bonw15

### DIFF
--- a/debian/system76-power.postrm
+++ b/debian/system76-power.postrm
@@ -7,6 +7,9 @@ case "$1" in
         rm -f /etc/modprobe.d/system76-power.conf
         rm -f /etc/modules-load.d/system76-power.conf
         systemctl enable nvidia-fallback.service || true
+        systemctl enable nvidia-hibernate.service || true
+        systemctl enable nvidia-resume.service || true
+        systemctl enable nvidia-suspend.service || true
         ;;
 
     *)


### PR DESCRIPTION
This contains two changes, gated on the bonw15 being detected, that should ensure proper NVIDIA driver suspend operation on bonw15:

- Disable PreserveVideoMemoryAllocations
- Disable NVIDIA hibernate, resume, and suspend services