### PR TITLE
Allow using Performance power profile on desktop

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -192,7 +192,7 @@ Battery power profile is not supported on desktop computers.
             }
             Some("performance") => client.performance(),
             _ => profile(&mut client).map_err(err_str),
-        }
+        },
         Args::Graphics { cmd } => {
             if !client.get_switchable()? {
                 return Err(String::from(

--- a/src/client.rs
+++ b/src/client.rs
@@ -179,17 +179,16 @@ pub fn client(args: &Args) -> Result<(), String> {
 
     match args {
         Args::Profile { profile: name } => {
-            if client.get_desktop()? {
-                return Err(String::from(
-                    r#"
-Power profiles are not supported on desktop computers.
-"#,
-                ));
-            }
-
             match name.as_deref() {
                 Some("balanced") => client.balanced(),
-                Some("battery") => client.battery(),
+                Some("battery") => {
+                  if client.get_desktop()? {
+                    return Err(String::from(r#"
+Battery power profile is not supported on desktop computers.
+"#));
+                  }
+                  client.battery()
+                },
                 Some("performance") => client.performance(),
                 _ => profile(&mut client).map_err(err_str),
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -178,20 +178,20 @@ pub fn client(args: &Args) -> Result<(), String> {
     let mut client = PowerClient::new()?;
 
     match args {
-        Args::Profile { profile: name } => {
-            match name.as_deref() {
-                Some("balanced") => client.balanced(),
-                Some("battery") => {
-                  if client.get_desktop()? {
-                    return Err(String::from(r#"
+        Args::Profile { profile: name } => match name.as_deref() {
+            Some("balanced") => client.balanced(),
+            Some("battery") => {
+                if client.get_desktop()? {
+                    return Err(String::from(
+                        r#"
 Battery power profile is not supported on desktop computers.
-"#));
-                  }
-                  client.battery()
-                },
-                Some("performance") => client.performance(),
-                _ => profile(&mut client).map_err(err_str),
+"#,
+                    ));
+                }
+                client.battery()
             }
+            Some("performance") => client.performance(),
+            _ => profile(&mut client).map_err(err_str),
         }
         Args::Graphics { cmd } => {
             if !client.get_switchable()? {


### PR DESCRIPTION
Fixes https://github.com/pop-os/system76-power/issues/424

This patch assumes https://github.com/pop-os/system76-power/commit/27192d28478e42a4d7fa4c21336f9abecb900188 specifically intended to disable Battery power profile on desktops, since desktop computers don't have battery power like laptops.  I don't know what the power profiles do internally, so please let me know if that assumption is incorrect.

Also ran `rustfmt` on the changed area of that file, hoping to keep code style consistent with existing code.