### PR TITLE
Gracefully handle missing brightness_hw_changed

### DIFF
--- a/src/hid_backlight.rs
+++ b/src/hid_backlight.rs
@@ -87,7 +87,9 @@ pub fn daemon() {
     let mut inotify = Inotify::init().unwrap();
     let mut watches = inotify.watches();
     watches.add(&brightness_file, WatchMask::MODIFY).unwrap();
-    watches.add(&brightness_hw_changed_file, WatchMask::MODIFY).unwrap();
+    if let Err(e) = watches.add(&brightness_hw_changed_file, WatchMask::MODIFY) {
+        log::warn!("hid_backlight: failed to watch hardware changed file: {}", e);
+    }
     if let Err(e) = watches.add(&color_file, WatchMask::MODIFY) {
         log::warn!("hid_backlight: failed to watch keyboard color: {}", e);
     }


### PR DESCRIPTION
Prevents missing `/sys/class/leds/system76_acpi::kbd_backlight/brightness_hw_changed` from causing a crash. Tested on a `lemp9` laptop under NixOS 23.11 with system76-power 1.1.26.

Closes #397