### PR TITLE
bonw15-b: TBT quirks, KBLED handling

### DIFF
--- a/src/hid_backlight.rs
+++ b/src/hid_backlight.rs
@@ -73,9 +73,13 @@ pub fn daemon() {
         }
     };
 
-    let dir = Path::new("/sys/class/leds/system76_acpi::kbd_backlight");
+    let mut dir = Path::new("/sys/class/leds/system76_acpi::kbd_backlight");
     if !dir.is_dir() {
-        log::error!("hid_backlight: no system76_acpi::kbd_backlight led");
+        // Check path from system76-dkms
+        dir = Path::new("/sys/class/leds/system76::kbd_backlight");
+    }
+    if !dir.is_dir() {
+        log::error!("hid_backlight: no kbd_backlight control");
         return;
     }
 

--- a/src/runtime_pm.rs
+++ b/src/runtime_pm.rs
@@ -17,6 +17,20 @@ pub fn runtime_pm_quirks(vendor: &str, model: &str) -> io::Result<()> {
                 }
             }
         }
+        ("System76", "bonw15-b") => {
+            for dev in PciDevice::all()? {
+                match (dev.vendor()?, dev.device()?) {
+                    (0x8086, 0x5782) => {
+                        log::info!(
+                            "Disabling runtime power management on Thunderbolt XHCI device at {:?}",
+                            dev.path()
+                        );
+                        dev.set_runtime_pm(RuntimePowerManagement::Off)?;
+                    }
+                    _ => (),
+                }
+            }
+        }
         _ => (),
     }
 

--- a/src/runtime_pm.rs
+++ b/src/runtime_pm.rs
@@ -1,12 +1,9 @@
 use std::{fs, io};
 use sysfs_class::{PciDevice, RuntimePM, RuntimePowerManagement, SysClass};
 
-pub fn runtime_pm_quirks() -> io::Result<()> {
-    let vendor = fs::read_to_string("/sys/class/dmi/id/sys_vendor")?;
-    let model = fs::read_to_string("/sys/class/dmi/id/product_version")?;
-
+pub fn runtime_pm_quirks(vendor: &str, model: &str) -> io::Result<()> {
     match (vendor.trim(), model.trim()) {
-        ("System76", "bonw15") | ("System76", "bonw15-b") => {
+        ("System76", "bonw15") => {
             for dev in PciDevice::all()? {
                 match (dev.vendor()?, dev.device()?) {
                     (0x8086, 0x1138) => {
@@ -21,6 +18,17 @@ pub fn runtime_pm_quirks() -> io::Result<()> {
             }
         }
         _ => (),
+    }
+
+    Ok(())
+}
+
+pub fn thunderbolt_hotplug_wakeup(vendor: &str, model: &str) -> io::Result<()> {
+    match (vendor.trim(), model.trim()) {
+        ("System76", "bonw15-b") => {
+            fs::read("/sys/kernel/debug/thunderbolt/0-0/regs")?;
+        }
+        (..) => {}
     }
 
     Ok(())


### PR DESCRIPTION
- Keep Thunderbolt controller active to work around display HPD issue
- Disable runtime power management for TBT xHCI
- Add handling for keyboard LED controls when using system76-dkms
- Check for `color_left` if `color` does not exist