### PR TITLE
fix: Match full_charge profile to firmware default values

### DIFF
--- a/src/charge_thresholds.rs
+++ b/src/charge_thresholds.rs
@@ -29,7 +29,7 @@ pub fn get_charge_profiles() -> Vec<ChargeProfile> {
             description: "Battery is charged to its full capacity for the longest possible use on \
                           battery power. Charging resumes when the battery falls below 96% charge."
                 .to_string(),
-            start:       96,
+            start:       90,
             end:         100,
         },
         ChargeProfile {


### PR DESCRIPTION
This should make `system76-power charge-thresholds` report the "Full Charge" profile by default on Open Firmware laptops, instead of reporting a "Custom" profile by default.