### PR TITLE
1.2.1: Allow use of apm_xgene temperatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "system76-power"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "system76-power-zbus"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "zbus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-power"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-power (1.2.1) jammy; urgency=medium
+
+  * Allow use of apm_xgene temperatures
+
+ -- Jeremy Soller <jeremy@system76.com>  Tue, 20 Aug 2024 15:53:24 -0600
+
 system76-power (1.2.0) jammy; urgency=medium
 
   * Rewrite dbus interface with zbus

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -480,7 +480,7 @@ impl UPowerPowerProfiles {
     async fn actions(&self) -> Vec<String> { vec![] }
 
     #[dbus_interface(property)]
-    async fn version(&self) -> &str { "system76-power 1.2.0" }
+    async fn version(&self) -> &str { "system76-power 1.2.1" }
 }
 
 pub struct NetHadessPowerProfiles(UPowerPowerProfiles);

--- a/src/fan.rs
+++ b/src/fan.rs
@@ -69,7 +69,7 @@ impl FanDaemon {
                     "amdgpu" => self.amdgpus.push(hwmon),
                     "system76" => (), // TODO: Support laptops
                     "system76_io" | "system76_thelio_io" => self.platforms.push(hwmon),
-                    "coretemp" | "k10temp" => self.cpus.push(hwmon),
+                    "apm_xgene" | "coretemp" | "k10temp" => self.cpus.push(hwmon),
                     _ => (),
                 }
             }

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-power-zbus"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This is to enable thelio-io on ampere desktops

Related to https://github.com/pop-os/system76-driver/pull/300