### PR TITLE
feat: enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ tokio = { version = "1.37", features = ["macros", "rt", "time", "signal"] }
 zbus = { version = "3.15.2", default-features = false, features = [ "tokio"] }
 zbus_polkit = { version = "3.0.0", features = ["tokio"] }
 zvariant = "3.15.2"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Hi!

I started a discussion about enabling Link-Time Optimization (LTO) across all pop!_os projects to improve their general performance (more compiler optimizations can be done with LTO) and the binary size reduction (LTO usually leads to measurable binary size improvements) here - https://github.com/pop-os/pop/discussions/3386 . In https://github.com/pop-os/pop/discussions/3386#discussioncomment-10909426 was proposed to create PRs into repos with enabling LTO - it's such a PR!

As a reference, I used the `system76-firmware` Release [profile](https://github.com/pop-os/system76-firmware/blob/master/Cargo.toml#L34).