### PR TITLE
Add mkinitcpio support

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -715,6 +715,8 @@ impl Graphics {
 fn update_initramfs_cmd() -> (&'static str, &'static str) {
     if path::Path::new("/usr/bin/dracut").exists() {
         ("dracut", "--force")
+    } else if path::Path::new("/usr/bin/mkinitcpio").exists() {
+        ("mkinitcpio", "-P")
     } else {
         ("update-initramfs", "-u")
     }


### PR DESCRIPTION
Prior to https://github.com/pop-os/system76-power/pull/460 , system76-power required `update-initramfs` exclusively.  Using system76-power on Arch Linux, which uses `mkinitcpio` for initramfs management, required the following patch:

https://aur.archlinux.org/cgit/aur.git/tree/use-mkinitcpio.patch?h=system76-power&id=0f49ee5b0bcda527abf55f5783e695528a9295d0

This PR builds on https://github.com/pop-os/system76-power/pull/460 and the above-linked AUR patch to add support for `mkinitcpio` without removing support for other initramfs management tools.

This PR is draft because:
 - I'm not sure how to reach this code path and test this change?  If it requires a System76 system with hybrid graphics, I have a gaze15 I could test this on if given instructions how to test.
 - Although it compiles in Rust 1.89, Clippy throws a lot of warnings that are unrelated to these changes?